### PR TITLE
soletta: add soletta-dev-app to be shipped to image that contains devkit

### DIFF
--- a/meta-ostro/recipes-core/packagegroups/packagegroup-devkit.bb
+++ b/meta-ostro/recipes-core/packagegroups/packagegroup-devkit.bb
@@ -9,4 +9,5 @@ RDEPENDS_${PN} = " \
     mraa \
     tempered \
     upm \
+    soletta-dev-app \
 "


### PR DESCRIPTION
Signed-off-by: Bruno Bottazzini <bruno.bottazzini@intel.com>

This patch will add Soletta Dev-App to be installed in images that contains packagroup-devkit. This package group contains IoT development kit related components. 

If the image is for production it should not contain the Dev-App, since it is an IDE for development purposes.