### PR TITLE
Manual combo-layer update from meta-java

### DIFF
--- a/conf/combo-layer.conf
+++ b/conf/combo-layer.conf
@@ -113,7 +113,7 @@ src_uri = git@github.com:intel-iot-devkit/meta-java.git
 dest_dir = meta-java
 hook = conf/combo-layerhook-generic.sh
 branch = openjdk-8
-last_revision = a9f2967c56cfe96fdfe31920a16d7aea8b3cb1d4
+last_revision = c6cffab1f1305de3971bc293305828132d912db5
 
 [meta-soletta]
 src_uri = git@github.com:solettaproject/meta-soletta.git

--- a/meta-java/recipes-core/openjdk/openjdk-8-60b27/icedtea-fix-adlc-flags.patch
+++ b/meta-java/recipes-core/openjdk/openjdk-8-60b27/icedtea-fix-adlc-flags.patch
@@ -1,0 +1,33 @@
+
+adlc is built using the native toolchain, not the crosscompiler. It however
+was incorrectly using flags meant for the crosscompiler.
+
+Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>
+---
+ openjdk/hotspot/make/linux/makefiles/adlc.make | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git openjdk/hotspot/make/linux/makefiles/adlc.make openjdk/hotspot/make/linux/makefiles/adlc.make
+index 8a86691..2789c03 100644
+--- openjdk/hotspot/make/linux/makefiles/adlc.make
++++ openjdk/hotspot/make/linux/makefiles/adlc.make
+@@ -28,6 +28,16 @@
+ 
+ include $(GAMMADIR)/make/$(Platform_os_family)/makefiles/rules.make
+ 
++# Yocto specific fix - remove target machine flags and replace them with
++# build machine flags, as this part is built using the native toolchain
++CXXFLAGS:=$(filter-out $(TARGET_CXXFLAGS),$(CXXFLAGS))
++CFLAGS:=$(filter-out $(TARGET_CFLAGS),$(CFLAGS))
++
++CXXFLAGS += $(BUILD_CXXFLAGS)
++CFLAGS += $(BUILD_CFLAGS)
++
++
++
+ # #########################################################################
+ 
+ # OUTDIR must be the same as AD_Dir = $(GENERATED)/adfiles in top.make:
+-- 
+1.9.1
+

--- a/meta-java/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
+++ b/meta-java/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
@@ -324,7 +324,19 @@ do_compile() {
         # cp -r images/j2re-compact3-image/bin ${B}/${BUILD_DIR}/j2re-image/
         # cp -r images/j2re-compact3-image/lib ${B}/${BUILD_DIR}/j2re-image/
 
+
+
+        # arm (beaglebone black) fix. JVM expects different name
+        if [ "x${JDK_ARCH}x" = "xarmx" ]; then
+          install -d -p ${D}/lib
+          ln -sf ld-linux-armhf.so.3 ${D}/lib/ld-linux.so.3
+        fi
+
 }
+
+# Part of arm fix: Add the symlink to the package
+FILES_${PN}_arm_append = " /lib/ld-linux.so.3"
+
 
 do_install() {
 

--- a/meta-java/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
+++ b/meta-java/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
@@ -585,16 +585,18 @@ OEPATCHES = "\
         file://faulty-nx-emulation.patch;apply=no \
         "
 
-ICEDTEAPATCHES = "\       
+ICEDTEAPATCHES = "\
         file://icedtea-fix-galileo-build.patch;apply=no \
         file://icedtea-fix-zero-mode-undefined-behaviour.patch;apply=no \
         file://icedtea-fix-sdt-search-path.patch;apply=no \
+        file://icedtea-fix-adlc-flags.patch;apply=no \
         "
 
 DISTRIBUTION_PATCHES = "\
         patches/icedtea-fix-galileo-build.patch \
         patches/icedtea-fix-zero-mode-undefined-behaviour.patch \
         patches/icedtea-fix-sdt-search-path.patch \
+        patches/icedtea-fix-adlc-flags.patch \
 	"
 
 export DISTRIBUTION_PATCHES


### PR DESCRIPTION
Pulls two patches from meta-java. First patch modifies the openjdk recipe to produce a missing symlink on ARM, which was causing java tests to fail. Second patch includes proper fix for the -fstack-protector issue, where target machine flags were used instead of the correct build machine flags.   