### PR TITLE
Manual combo-layer update from meta-java

### DIFF
--- a/conf/combo-layer.conf
+++ b/conf/combo-layer.conf
@@ -113,7 +113,7 @@ src_uri = git@github.com:intel-iot-devkit/meta-java.git
 dest_dir = meta-java
 hook = conf/combo-layerhook-generic.sh
 branch = openjdk-8
-last_revision = c6cffab1f1305de3971bc293305828132d912db5
+last_revision = e53735323f3d827ff4dbbf1fb274806060356eff
 
 [meta-soletta]
 src_uri = git@github.com:solettaproject/meta-soletta.git

--- a/meta-java/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
+++ b/meta-java/recipes-core/openjdk/openjdk-8_60b27-2.5.4.bb
@@ -324,14 +324,6 @@ do_compile() {
         # cp -r images/j2re-compact3-image/bin ${B}/${BUILD_DIR}/j2re-image/
         # cp -r images/j2re-compact3-image/lib ${B}/${BUILD_DIR}/j2re-image/
 
-
-
-        # arm (beaglebone black) fix. JVM expects different name
-        if [ "x${JDK_ARCH}x" = "xarmx" ]; then
-          install -d -p ${D}/lib
-          ln -sf ld-linux-armhf.so.3 ${D}/lib/ld-linux.so.3
-        fi
-
 }
 
 # Part of arm fix: Add the symlink to the package
@@ -359,6 +351,13 @@ do_install() {
         install -m644 ${WORKDIR}/jvm.cfg  ${D}${JDK_HOME}/jre/lib/${JDK_ARCH}/
         # workaround for shared libarary searching
         ln -sf server/libjvm.so ${D}${JDK_HOME}/jre/lib/${JDK_ARCH}/
+
+        # arm (beaglebone black) fix. JVM expects different name
+        if [ "x${JDK_ARCH}x" = "xarmx" ]; then
+          bbnote "Creating arm ld symlink"
+          install -d -p ${D}/lib
+          ln -sf ld-linux-armhf.so.3 ${D}/lib/ld-linux.so.3
+        fi
 }
 
 # Notes about the ideas behind packaging:


### PR DESCRIPTION
Contains fix for the broken beaglebone java fix. Symlink creation is moved from compile step to install step.

I'm unsure why it fails when done at do_compile step, but works in do_install, and why it initially worked for me locally. 