### PR TITLE
combo layer: add meta-swupd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ hob-image-*.bb
 !/meta-skeleton
 !/meta-soletta
 !/meta-yocto
+!/meta-swupd
+

--- a/conf/combo-layer-local-sample.conf
+++ b/conf/combo-layer-local-sample.conf
@@ -48,3 +48,6 @@ local_repo_dir = ../meta-java
 
 [meta-soletta]
 local_repo_dir = ../meta-soletta
+
+[meta-swupd]
+local_repo_dir = ../meta-swupd

--- a/conf/combo-layer.conf
+++ b/conf/combo-layer.conf
@@ -122,3 +122,9 @@ hook = conf/combo-layerhook-generic.sh
 branch = master
 last_revision = 708e5b9bd7c6cfd008e98249e09818bca12b63d0
 
+[meta-swupd]
+src_uri = git://git.yoctoproject.org/meta-swupd
+dest_dir = meta-swupd
+hook = conf/combo-layerhook-generic.sh
+branch = master
+last_revision =


### PR DESCRIPTION
This is the necessary change in the combined repo. The rest of the changes will follow in meta-ostro.

I can also include a manual pull here; I haven't done that because if you want to see the commits, then you can look at PR #25.

@kad @olev: do we also need an upstream monitor job configured somewhere for meta-swupd?

