### PR TITLE
swupd: update /etc

### DIFF
--- a/meta-ostro/classes/ostro-image.bbclass
+++ b/meta-ostro/classes/ostro-image.bbclass
@@ -438,3 +438,23 @@ ostro_image_patch_os_release[vardepsexclude] = " \
     BUILD_ID \
 "
 ROOTFS_POSTPROCESS_COMMAND += "ostro_image_patch_os_release; "
+
+# The systemd-firstboot service makes no sense in Ostro. If it runs
+# (apparently triggered by not having an /etc/machine-id), it asks
+# interactively on the console for a default timezone and locale. We
+# cannot rely on users answering these questions.
+#
+# Instead we pre-configure some defaults in the image and can remove
+# the useless service.
+ostro_image_disable_firstboot () {
+    for i in /etc/systemd /lib/systemd /usr/lib/systemd /bin /usr/bin; do
+        d="${IMAGE_ROOTFS}$i"
+        if [ -d "$d" ] && [ ! -h "$d" ]; then
+            for e in $(find "$d" -name systemd-firstboot.service -o -name systemd-firstboot.service.d -o -name systemd-firstboot); do
+                echo "disable_firstboot: removing $e"
+                rm -rf "$e"
+            done
+        fi
+    done
+}
+ROOTFS_POSTPROCESS_COMMAND += "ostro_image_disable_firstboot; "

--- a/meta-ostro/classes/stateless.bbclass
+++ b/meta-ostro/classes/stateless.bbclass
@@ -1,0 +1,282 @@
+# This moves files out of /etc. It gets applied both
+# to individual packages (to avoid or at least catch problems
+# early) as well as the entire rootfs (to catch files not
+# contained in packages).
+
+# Package QA check which greps for known bad paths which should
+# not be used anymore, like files which used to be in /etc and
+# got moved elsewhere.
+STATELESS_DEPRECATED_PATHS ??= ""
+
+# Check not activated by default, can be done in distro with:
+# ERROR_QA += "stateless"
+
+# If set to True, a recipe gets configured with
+# sysconfdir=${datadir}/defaults. If set to a path, that
+# path is used instead. In both cases, /etc typically gets
+# ignored and the component no longer can be configured by
+# the device admin.
+STATELESS_RELOCATE ??= "False"
+
+# A space-separated list of recipes which may contain files in /etc.
+STATELESS_PN_WHITELIST ??= ""
+
+# A space-separated list of shell patterns. Anything matching a
+# pattern is allowed in /etc. Changing this influences the QA check in
+# do_package and do_rootfs.
+STATELESS_ETC_WHITELIST ??= "${STATELESS_ETC_DIR_WHITELIST}"
+
+# A subset of STATELESS_ETC_WHITELIST which also influences do_install
+# and determines which directories to keep.
+STATELESS_ETC_DIR_WHITELIST ??= ""
+
+# A space-separated list of entries in /etc which need to be moved
+# away. Default is to move into ${datadir}/doc/${PN}/etc. The actual
+# new name can also be given with old-name=new-name, as in
+# "pam.d=${datadir}/pam.d".
+STATELESS_MV ??= ""
+
+# A space-separated list of entries in /etc which can be removed
+# entirely.
+STATELESS_RM ??= ""
+
+# Same as the previous ones, except that they get applied to the rootfs
+# before running ROOTFS_POSTPROCESS_COMMANDs.
+STATELESS_RM_ROOTFS ??= ""
+STATELESS_MV_ROOTFS ??= ""
+
+###########################################################################
+
+def stateless_is_whitelisted(etcentry, whitelist):
+    import fnmatch
+    for pattern in whitelist:
+        if fnmatch.fnmatchcase(etcentry, pattern):
+            return True
+    return False
+
+def stateless_mangle(d, root, docdir, stateless_mv, stateless_rm, dirwhitelist, is_package):
+    import os
+    import errno
+    import shutil
+
+    # Remove content that is no longer needed.
+    for entry in stateless_rm:
+        old = os.path.join(root, 'etc', entry)
+        if os.path.exists(old) or os.path.islink(old):
+            bb.note('stateless: removing %s' % old)
+            if os.path.isdir(old) and not os.path.islink(old):
+                shutil.rmtree(old)
+            else:
+                os.unlink(old)
+
+    # Move away files. Default target is docdir, but others can
+    # be set by appending =<new name> to the entry, as in
+    # tmpfiles.d=libdir/tmpfiles.d
+    for entry in stateless_mv:
+        paths = entry.split('=', 1)
+        etcentry = paths[0]
+        old = os.path.join(root, 'etc', etcentry)
+        if os.path.exists(old) or os.path.islink(old):
+            if len(paths) > 1:
+                new = root + paths[1]
+            else:
+                new = os.path.join(docdir, entry)
+            destdir = os.path.dirname(new)
+            bb.utils.mkdirhier(destdir)
+            # Also handles moving of directories where the target already exists, by
+            # moving the content. When moving a relative symlink the target gets updated.
+            def move(old, new):
+                bb.note('stateless: moving %s to %s' % (old, new))
+                if os.path.isdir(new):
+                    for entry in os.listdir(old):
+                        move(os.path.join(old, entry), os.path.join(new, entry))
+                    os.rmdir(old)
+                else:
+                    os.rename(old, new)
+            move(old, new)
+
+    # Remove /etc if all that's left are directories.
+    # Some directories are expected to exists (for example,
+    # update-ca-certificates depends on /etc/ssl/certs),
+    # so if a directory is white-listed, it does not get
+    # removed.
+    etcdir = os.path.join(root, 'etc')
+    def tryrmdir(path):
+        if is_package and \
+           path.endswith('/etc/modprobe.d') or \
+           path.endswith('/etc/modules-load.d'):
+           # Expected to exist by kernel-module-split.bbclass
+           # which will clean it itself.
+           return
+        if stateless_is_whitelisted(path[len(etcdir) + 1:], dirwhitelist):
+           bb.note('stateless: keeping white-listed directory %s' % path)
+           return
+        bb.note('stateless: removing dir %s' % path)
+        try:
+            os.rmdir(path)
+        except OSError, ex:
+            bb.note('stateless: removing dir failed: %s' % ex)
+            if ex.errno != errno.ENOTEMPTY:
+                 raise
+    if os.path.isdir(etcdir):
+        for root, dirs, files in os.walk(etcdir, topdown=False):
+            for dir in dirs:
+                path = os.path.join(root, dir)
+                if os.path.islink(path):
+                    files.append(dir)
+                else:
+                    tryrmdir(path)
+            for file in files:
+                bb.note('stateless: /etc not empty: %s' % os.path.join(root, file))
+        tryrmdir(etcdir)
+
+
+# Modify ${D} after do_install and before do_package resp. do_populate_sysroot.
+do_install[postfuncs] += "stateless_mangle_package"
+python stateless_mangle_package() {
+    pn = d.getVar('PN', True)
+    if pn in (d.getVar('STATELESS_PN_WHITELIST', True) or '').split():
+        return
+    installdir = d.getVar('D', True)
+    docdir = installdir + os.path.join(d.getVar('docdir', True), pn, 'etc')
+    whitelist = (d.getVar('STATELESS_ETC_DIR_WHITELIST', True) or '').split()
+
+    stateless_mangle(d, installdir, docdir,
+                     (d.getVar('STATELESS_MV', True) or '').split(),
+                     (d.getVar('STATELESS_RM', True) or '').split(),
+                     whitelist,
+                     True)
+}
+
+# Check that nothing is left in /etc.
+PACKAGEFUNCS += "stateless_check"
+python stateless_check() {
+    pn = d.getVar('PN', True)
+    if pn in (d.getVar('STATELESS_PN_WHITELIST', True) or '').split():
+        return
+    whitelist = (d.getVar('STATELESS_ETC_WHITELIST', True) or '').split()
+    import os
+    sane = True
+    for pkg, files in pkgfiles.iteritems():
+        pkgdir = os.path.join(d.getVar('PKGDEST', True), pkg)
+        for file in files:
+            targetfile = file[len(pkgdir):]
+            if targetfile.startswith('/etc/') and \
+               not stateless_is_whitelisted(targetfile[len('/etc/'):], whitelist):
+                bb.warn("stateless: %s should not contain %s" % (pkg, file))
+                sane = False
+    if not sane:
+        d.setVar("QA_SANE", "")
+}
+
+QAPATHTEST[stateless] = "stateless_qa_check_paths"
+def stateless_qa_check_paths(file,name, d, elf, messages):
+    """
+    Check for deprecated paths that should no longer be used.
+    """
+
+    if os.path.islink(file):
+        return
+
+    # Ignore ipk and deb's CONTROL dir
+    if file.find(name + "/CONTROL/") != -1 or file.find(name + "/DEBIAN/") != -1:
+        return
+
+    bad_paths = d.getVar('STATELESS_DEPRECATED_PATHS', True).split()
+    if bad_paths:
+        import subprocess
+        import pipes
+        cmd = "strings -a %s | grep -F '%s' | sort -u" % (pipes.quote(file), '\n'.join(bad_paths))
+        s = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = s.communicate()
+        # Cannot check return code, some of them may get lost because we use a pipe
+        # and cannot rely on bash's pipefail. Instead just check for unexpected
+        # stderr content.
+        if stderr:
+            bb.fatal('Checking %s for paths deprecated via STATELESS_DEPRECATED_PATHS failed:\n%s' % (file, stderr))
+        if stdout:
+            package_qa_add_message(messages, "stateless", "%s: %s contains paths deprecated in a stateless configuration: %s" % (name, package_qa_clean_path(file, d), stdout))
+do_package_qa[vardeps] += "stateless_qa_check_paths"
+
+python () {
+    # The bitbake cache must be told explicitly that changes in the
+    # directories have an effect on the recipe. Otherwise adding
+    # or removing patches or whole directories does not trigger
+    # re-parsing and re-building.
+    import os
+    patchdir = d.expand('${STATELESS_PATCHES_BASE}/${PN}')
+    bb.parse.mark_dependency(d, patchdir)
+    if os.path.isdir(patchdir):
+        patches = os.listdir(patchdir)
+        if patches:
+            filespath = d.getVar('FILESPATH', True)
+            d.setVar('FILESPATH', filespath + ':' + patchdir)
+            srcuri = d.getVar('SRC_URI', True)
+            d.setVar('SRC_URI', srcuri + ' ' + ' '.join(['file://' + x for x in sorted(patches)]))
+
+    # Dynamically reconfigure the package to use /usr instead of /etc for
+    # configuration files.
+    relocate = d.getVar('STATELESS_RELOCATE', True)
+    if relocate != 'False':
+        defaultsdir = d.expand('${datadir}/defaults') if relocate == 'True' else relocate
+        d.setVar('sysconfdir', defaultsdir)
+        d.setVar('EXTRA_OECONF', d.getVar('EXTRA_OECONF', True) + " --sysconfdir=" + defaultsdir)
+}
+
+# Several post-install scripts modify /etc.
+# For example:
+# /etc/shells - gets extended when installing a shell package
+# /etc/passwd - adduser in postinst extends it
+# /etc/systemd/system - has several .wants entries
+#
+# We fix this directly after the write_image_manifest command
+# in the ROOTFS_POSTUNINSTALL_COMMAND.
+#
+# However, that is very late, so changes made by a ROOTFS_POSTPROCESS_COMMAND
+# (like setting an empty root password) become part of the system,
+# which might not be intended in all cases.
+#
+# It would be better to do this directly after installing with
+# ROOTFS_POSTINSTALL_COMMAND += "stateless_mangle_rootfs;"
+# However, opkg then becomes unhappy and causes failures in the
+# *_manifest commands which get executed later:
+#
+# ERROR: Cannot get the installed packages list. Command '.../opkg -f .../ostro-image-minimal/1.0-r0/opkg.conf -o .../ostro-image-minimal/1.0-r0/rootfs  --force_postinstall --prefer-arch-to-version   status' returned 0 and stderr:
+# Collected errors:
+#  * file_md5sum_alloc: Failed to open file .../ostro-image-minimal/1.0-r0/rootfs/etc/hosts: No such file or directory.
+#
+# ERROR: Function failed: write_package_manifest
+#
+# TODO: why does opkg complain? /etc/hosts is listed in CONFFILES of netbase,
+# so it should be valid to remove it. If we can fix that and ensure that
+# all /etc files are marked as CONFFILES (perhaps by adding that as
+# default for all packages), then we can use ROOTFS_POSTINSTALL_COMMAND
+# again.
+ROOTFS_POSTUNINSTALL_COMMAND_append = "stateless_mangle_rootfs;"
+
+python stateless_mangle_rootfs () {
+    pn = d.getVar('PN', True)
+    if pn in (d.getVar('STATELESS_PN_WHITELIST', True) or '').split():
+        return
+
+    rootfsdir = d.getVar('IMAGE_ROOTFS', True)
+    docdir = rootfsdir + d.getVar('datadir', True) + '/doc/etc'
+    whitelist = (d.getVar('STATELESS_ETC_WHITELIST', True) or '').split()
+    stateless_mangle(d, rootfsdir, docdir,
+                     (d.getVar('STATELESS_MV_ROOTFS', True) or '').split(),
+                     (d.getVar('STATELESS_RM_ROOTFS', True) or '').split(),
+                     whitelist,
+                     False)
+    import os
+    etcdir = os.path.join(rootfsdir, 'etc')
+    valid = True
+    for dirpath, dirnames, filenames in os.walk(etcdir):
+        for entry in filenames + [x for x in dirnames if os.path.islink(x)]:
+            fullpath = os.path.join(dirpath, entry)
+            etcentry = fullpath[len(etcdir) + 1:]
+            if not stateless_is_whitelisted(etcentry, whitelist):
+                bb.warn('stateless: rootfs should not contain %s' % fullpath)
+                valid = False
+    if not valid:
+        bb.fatal('stateless: /etc not empty')
+}

--- a/meta-ostro/conf/distro/include/stateless.inc
+++ b/meta-ostro/conf/distro/include/stateless.inc
@@ -15,3 +15,46 @@ STATELESS_ETC_WHITELIST += "*"
 STATELESS_ETC_DIR_WHITELIST += "*"
 
 ###########################################################################
+
+# As an intermediate step towards full stateless Ostro OS, we now
+# treat some files in /etc as conceptually read-only (i.e. neither
+# modified by the OS at runtime nor by an admin). Anything contained
+# in the rootfs directories will get bundled and added or updated when
+# running "swupd update".
+#
+# The implication is that we must keep certain files out of the rootfs
+# which do get modified at runtime, because otherwise there are
+# "swupd verify" failures.
+
+# OE-core puts some files into /etc which systemd then later overwrites
+# unconditionally via /usr/lib/tmpfile.d/etc.conf or creates dynamically
+# (machine-id). Therefore we can remove the redundant files from our rootfs
+# by not packaging them in the first place.
+#
+# Booting without /etc/machine-id triggers the "first boot" condition,
+# used for example by systemd-firstboot.service. That service is
+# not usable in Ostro OS (depends on user input) and therefore has
+# to be disabled when removing machine-id.
+STATELESS_RM_pn-base-files += " \
+    mtab \
+"
+STATELESS_RM_pn-systemd += " \
+    machine-id \
+    resolv.conf \
+"
+
+# Depend on the installed components and thus has to be computed on
+# the device. Handled by systemd during booting or updates.
+STATELESS_RM_ROOTFS += " \
+    udev/hwdb.bin \
+"
+
+# Disable creation of /etc/ld.so.cache in images and bundles. The file
+# gets already recreated by systemd anyway when booting. Has to be
+# done by unsetting LDCONFIGDEPEND (checked by rootfs.py, which
+# creates the ld.so.cache) for all Ostro OS images, but not the
+# ostro-initramfs, so we cannot set it unconditionally.
+python () {
+    if bb.data.inherits_class('ostro-image', d):
+        d.setVar('LDCONFIGDEPEND', '')
+}

--- a/meta-ostro/conf/distro/include/stateless.inc
+++ b/meta-ostro/conf/distro/include/stateless.inc
@@ -1,0 +1,17 @@
+INHERIT += "stateless"
+
+###########################################################################
+
+# Temporary overrides until Ostro OS is fully stateless.
+
+# This entry here allows everything in /etc because Ostro OS is
+# not actually stateless yet. We merely use the stateless.bbclass
+# to remove files from /etc which get written on the device
+# and thus must be excluded from images and, more importantly,
+# swupd bundles.
+STATELESS_ETC_WHITELIST += "*"
+
+# Empty directories must be kept.
+STATELESS_ETC_DIR_WHITELIST += "*"
+
+###########################################################################

--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -150,6 +150,10 @@ DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit pulseaudio"
 require conf/distro/include/ostro_security_flags.inc
 require conf/distro/include/ostro-x11.inc
 
+# Build distro stateless, i.e. with /etc empty straight out of the box
+# and reserved for customizations by the admin.
+require conf/distro/include/stateless.inc
+
 # QA check settings - a little stricter than the OE-Core defaults
 WARN_TO_ERROR_QA = "already-stripped compile-host-path install-host-path \
                     installed-vs-shipped ldflags pn-overrides rpaths staticdev \

--- a/meta-ostro/conf/layer.conf
+++ b/meta-ostro/conf/layer.conf
@@ -15,6 +15,10 @@ META_OSTRO_BASE := '${LAYERDIR}'
 # Used by image-dsk.bbclass to find lib/image-dsk.py.
 IMAGE_DSK_BASE ?= '${META_OSTRO_BASE}'
 
+# Required by stateless.bbclass to find patches needed only when
+# compiling stateless.
+STATELESS_PATCHES_BASE ?= "${META_OSTRO_BASE}/conf/distro/stateless-patches"
+
 BBFILE_COLLECTIONS += "ostro"
 BBFILE_PATTERN_ostro := "^${LAYERDIR}/"
 BBFILE_PRIORITY_ostro = "6"

--- a/meta-ostro/recipes-swupd/swupd-client/swupd-client_%.bbappend
+++ b/meta-ostro/recipes-swupd/swupd-client/swupd-client_%.bbappend
@@ -2,6 +2,9 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 inherit systemd
 
+# Make swupd "stateful" by letting it update files in /etc.
+PACKAGECONFIG_remove = "stateless"
+
 SRC_URI_append = "file://0001-Disable-boot-file-heuristics.patch \
                   file://efi_combo_updater.c \
                   ${@ 'file://efi-combo-trigger.service' if ${OSTRO_USE_DSK_IMAGES} else ''} \

--- a/meta-ostro/recipes-swupd/swupd-client/swupd-client_%.bbappend
+++ b/meta-ostro/recipes-swupd/swupd-client/swupd-client_%.bbappend
@@ -11,6 +11,7 @@ SRC_URI_append = "file://0001-Disable-boot-file-heuristics.patch \
                  "
 
 RDEPENDS_${PN}_class-target_append = "${@ ' gptfdisk' if ${OSTRO_USE_DSK_IMAGES} else '' }"
+DEPENDS_${PN}_append = " xattr-native"
 
 # Get rid of check-update entirely, otherwise we cannot enable
 # auto-activation.
@@ -38,4 +39,13 @@ do_install_append () {
 
     # Don't install and enable check-update.timer by default
     rm -f ${D}/${systemd_system_unitdir}/check-update.* ${D}/${systemd_system_unitdir}/multi-user.target.wants/check-update.*
+}
+
+pkg_postinst_${PN}_append () {
+    # Setting a label explicitly on the directory prevents it
+    # from inheriting other undesired attributes like security.SMACK64TRANSMUTE
+    # from upper folders (see xattr-images.bbclass for details).
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'smack', 'true', 'false', d)}; then
+       setfattr -n security.SMACK64 -v "_" $D/var/lib/swupd
+    fi
 }

--- a/meta-swupd/recipes-core/swupd-client/swupd-client/0001-Add-configure-option-to-re-enable-updating-of-config.patch
+++ b/meta-swupd/recipes-core/swupd-client/swupd-client/0001-Add-configure-option-to-re-enable-updating-of-config.patch
@@ -1,0 +1,58 @@
+From 1f2ad4cdff6b999fcd00193cdd1dc8a35e49c0b2 Mon Sep 17 00:00:00 2001
+From: Joshua Lock <joshua.g.lock@intel.com>
+Date: Thu, 3 Mar 2016 19:55:41 +0000
+Subject: [PATCH] Add configure option to re-enable updating of config files
+
+Signed-off-by: Joshua Lock <joshua.g.lock@intel.com>
+
+Upstream-Status: Pending
+
+---
+ configure.ac     | 7 +++++++
+ src/heuristics.c | 5 +++--
+ 2 files changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index f94a17d..0063463 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -78,6 +78,13 @@ AC_ARG_ENABLE(
+ 	enable_linux_rootfs_build="no"
+ )
+ 
++AC_ARG_ENABLE(
++        [stateless],
++        AS_HELP_STRING([--disable-stateless],[OS is not stateless, do not ignore configuration files (stateless by default)]),
++        AC_DEFINE(OS_IS_STATELESS,0,[OS is not stateless]),
++        AC_DEFINE(OS_IS_STATELESS,1,[OS is stateless])
++)
++
+ AS_IF([test "$enable_linux_btrfs_build" = "yes" -a "$enable_android_build" = "yes"],
+       [AC_MSG_ERROR([Cannot enable more than one build variant. Choose a single variant.])])
+ 
+diff --git a/src/heuristics.c b/src/heuristics.c
+index 12fb59c..92dbcdc 100644
+--- a/src/heuristics.c
++++ b/src/heuristics.c
+@@ -27,6 +27,7 @@
+ #include <string.h>
+ #include <assert.h>
+ 
++#include <config.h>
+ #include <swupd.h>
+ 
+ /* trailing slash is to indicate dir itself is expected to exist, but
+@@ -113,8 +114,8 @@ void apply_heuristics(struct file *file)
+ 
+ bool ignore(struct file *file)
+ {
+-	if ((file->is_config) ||
+-	    is_config(file->filename) || // ideally we trust the manifest but short term reapply check here
++	if ((OS_IS_STATELESS && file->is_config) ||
++	    (OS_IS_STATELESS && is_config(file->filename)) || // ideally we trust the manifest but short term reapply check here
+ 	    (file->is_state) ||
+ 	    is_state(file->filename) || // ideally we trust the manifest but short term reapply check here
+ 	    (file->is_boot &&  fix &&  file->is_deleted) || // shouldn't happen
+-- 
+2.5.0
+

--- a/meta-swupd/recipes-core/swupd-client/swupd-client_2.87.bb
+++ b/meta-swupd/recipes-core/swupd-client/swupd-client_2.87.bb
@@ -14,6 +14,7 @@ SRC_URI = "\
     file://0007-Add-compatibility-with-libarchive-s-bsdtar-command.patch \
     file://0001-log.c-avoid-segfault-and-show-staging-file-name.patch \
     file://0002-downloads-minimize-syscalls-to-improve-performance.patch \
+    file://0001-Add-configure-option-to-re-enable-updating-of-config.patch \
 "
 
 SRC_URI[md5sum] = "5d272c62edb8a9c576005ac5e1182ea3"
@@ -27,6 +28,9 @@ RRECOMMENDS_${PN}_class-target = "os-release"
 inherit pkgconfig autotools-brokensep systemd
 
 EXTRA_OECONF = "--with-systemdsystemunitdir=${systemd_system_unitdir} --enable-bsdtar"
+
+PACKAGECONFIG ??= "stateless"
+PACKAGECONFIG[stateless] = ",--disable-stateless"
 
 #TODO: create and install /var/lib/swupd/{delta,staged/download}
 do_install_append () {


### PR DESCRIPTION
Test build with one pending patch for meta-swupd and several for meta-ostro.

Local builds with limited bundle content (just valgrind) shows that
"swupd verify" passes for the os-core although swupd client is configured
such that it no longer excludes /etc.