### PR TITLE
test build with fixes for bundle removal in swupd-client

### DIFF
--- a/meta-swupd/recipes-core/swupd-client/swupd-client-2.87/0001-globals.c-Use-fake-address-as-default-updates-url.patch
+++ b/meta-swupd/recipes-core/swupd-client/swupd-client-2.87/0001-globals.c-Use-fake-address-as-default-updates-url.patch
@@ -1,0 +1,37 @@
+From e7af0013dd550c72641ea841f1177d6b0af99dce Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+Date: Fri, 15 Apr 2016 10:02:45 +0300
+Subject: [PATCH] globals.c: Use fake address as default updates' url
+
+If a user forgets to provide its swupd server URL then
+ClearLinux's default is used unconditionally which may
+reult in a corrupted system.
+
+Upstream-Status: Inappropriate [latest code doesn't use hardcoded defaults]
+
+Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+---
+ src/globals.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/globals.c b/src/globals.c
+index 8ca3fd9..0e78f34 100644
+--- a/src/globals.c
++++ b/src/globals.c
+@@ -62,11 +62,11 @@ bool have_network = false; /* assume no access until proved */
+ #define URL_COUNT 2
+ char *version_server_urls[URL_COUNT] = {
+ 	NULL,
+-	"https://download.clearlinux.org/update",
++	"https://example.com/update",
+ };
+ char *content_server_urls[URL_COUNT] = {
+ 	NULL,
+-	"https://download.clearlinux.org/update",
++	"https://example.com/update",
+ };
+ char *preferred_version_url;
+ char *preferred_content_url;
+-- 
+2.5.0
+

--- a/meta-swupd/recipes-core/swupd-client/swupd-client-2.87/0001-manifest.c-Always-initialize-preserver-pointer-of-fi.patch
+++ b/meta-swupd/recipes-core/swupd-client/swupd-client-2.87/0001-manifest.c-Always-initialize-preserver-pointer-of-fi.patch
@@ -1,0 +1,34 @@
+From ad26f092f1b2102bf6e298a2a6dd8115f4e88d99 Mon Sep 17 00:00:00 2001
+From: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+Date: Fri, 15 Apr 2016 18:36:57 +0300
+Subject: [PATCH] manifest.c: Always initialize preserver pointer of file list
+
+In case a bundle has nothing in common with any other installed
+bundle (no files duplicated in different bundles) the preserver
+pointer inside deduplicate_files_from_manifest() isn't
+initialized which leads to NULL as output of the function.
+As result no files of the deleted bundle get deleted at all.
+
+Upstream-Status: Backported [v3.5.0+]
+
+Signed-off-by: Dmitry Rozhkov <dmitry.rozhkov@linux.intel.com>
+---
+ src/manifest.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/manifest.c b/src/manifest.c
+index 7c356d7..10b7daa 100644
+--- a/src/manifest.c
++++ b/src/manifest.c
+@@ -1326,7 +1326,7 @@ void deduplicate_files_from_manifest(struct manifest **m1, struct manifest *m2)
+ 	int count = 0;
+ 
+ 	bmanifest = *m1;
+-	iter1 = list_head(bmanifest->files);
++	iter1 = preserver = list_head(bmanifest->files);
+ 	iter2 = list_head(m2->files);
+ 
+ 	while (iter1 && iter2) {
+-- 
+2.5.0
+

--- a/meta-swupd/recipes-core/swupd-client/swupd-client_2.87.bb
+++ b/meta-swupd/recipes-core/swupd-client/swupd-client_2.87.bb
@@ -15,6 +15,7 @@ SRC_URI = "\
     file://0001-log.c-avoid-segfault-and-show-staging-file-name.patch \
     file://0002-downloads-minimize-syscalls-to-improve-performance.patch \
     file://0001-globals.c-Use-fake-address-as-default-updates-url.patch \
+    file://0001-manifest.c-Always-initialize-preserver-pointer-of-fi.patch \
 "
 
 SRC_URI[md5sum] = "5d272c62edb8a9c576005ac5e1182ea3"

--- a/meta-swupd/recipes-core/swupd-client/swupd-client_2.87.bb
+++ b/meta-swupd/recipes-core/swupd-client/swupd-client_2.87.bb
@@ -14,6 +14,7 @@ SRC_URI = "\
     file://0007-Add-compatibility-with-libarchive-s-bsdtar-command.patch \
     file://0001-log.c-avoid-segfault-and-show-staging-file-name.patch \
     file://0002-downloads-minimize-syscalls-to-improve-performance.patch \
+    file://0001-globals.c-Use-fake-address-as-default-updates-url.patch \
 "
 
 SRC_URI[md5sum] = "5d272c62edb8a9c576005ac5e1182ea3"


### PR DESCRIPTION
Also changes update server URL to a fake address to avoid accidental updates to ClearLinux.