### PR TITLE
Test PR for multilib bug

### DIFF
--- a/meta-ostro/conf/distro/ostro.conf
+++ b/meta-ostro/conf/distro/ostro.conf
@@ -408,3 +408,5 @@ EXCLUDE_FROM_WORLD_pn-swupd-server = "1"
 # soletta-dev-app breaks builds in CI due to npm install and network
 # problems with it. Temporarily skip the build.
 EXCLUDE_FROM_WORLD_pn-soletta-dev-app = "1"
+
+require conf/ostro-multilib.conf

--- a/meta-ostro/conf/ostro-multilib.conf
+++ b/meta-ostro/conf/ostro-multilib.conf
@@ -1,16 +1,20 @@
 require conf/distro/ostro.conf
 require conf/multilib.conf
 
+LIB32_ARCH = "${X86ARCH32}"
+LIB32_ARCH_arm = "${TARGET_ARCH}"
+
 MULTILIBS = "multilib:lib32"
 DEFAULTTUNE_virtclass-multilib-lib32 = "x86"
+DEFAULTTUNE_virtclass-multilib-lib32_arm = "armv7a"
 baselib_virtclass-multilib-lib32 = "lib32"
 LIBCEXTENSION_virtclass-multilib-lib32 = "-uclibc"
 LIBCOVERRIDE_virtclass-multilib-lib32 = ":libc-uclibc"
 PREFERRED_PROVIDER_virtual/lib32-libc ?= "lib32-uclibc"
 PREFERRED_PROVIDER_virtual/lib32-libiconv ?= "lib32-libiconv"
 PREFERRED_PROVIDER_virtual/lib32-libintl ?= "lib32-gettext"
-PREFERRED_PROVIDER_virtual/lib32-${TARGET_ARCH}-ostromllib32-linux-uclibc-libc-for-gcc = "lib32-uclibc"
-PREFERRED_PROVIDER_virtual/lib32-${TARGET_ARCH}-ostromllib32-linux-uclibc-libc-initial = "lib32-uclibc-initial"
+PREFERRED_PROVIDER_virtual/lib32-${LIB32_ARCH}-ostromllib32-linux-uclibc${ABIEXTENSION}-libc-for-gcc = "lib32-uclibc"
+PREFERRED_PROVIDER_virtual/lib32-${LIB32_ARCH}-ostromllib32-linux-uclibc${ABIEXTENSION}-libc-initial = "lib32-uclibc-initial"
 USE_NLS_virtclass-multilib-lib32 ?= "no"
 CXXFLAGS_append_virtclass-multilib-lib32 = " -fvisibility-inlines-hidden"
 IMAGE_LINGUAS_virtclass-multilib-lib32 = ""

--- a/meta-ostro/conf/ostro-multilib.conf
+++ b/meta-ostro/conf/ostro-multilib.conf
@@ -1,4 +1,5 @@
-require conf/distro/ostro.conf
+# Disabled to prevent recursion with ostro.conf when testing in CI
+#require conf/distro/ostro.conf
 require conf/multilib.conf
 
 LIB32_ARCH = "${X86ARCH32}"


### PR DESCRIPTION
This is a test PR for the multilib bug. ostro-multilib.conf is modified to fix the Beaglebone and corei7-64 builds. This PR additionally contains a commit to enable the multilib configuration in order to enable CI testing; this is not intended to be part of the final PR.

64 bit intel-corei7-64 build fails, as the PREFERRED_PROVIDER is not
properly overridden. The multilib provider has the form
PREFERRED_PROVIDER_virtual/lib32-i686-...., while the provider set in
ostro-multilib.conf expands to PREFERRED_PROVIDER_virtual/lib32-x86_64,
as x86_64 is what the target architecture is.

Beaglebone build fails, as the DEFAULTTUNE is set to unconditionally
contain tune arguments for x86 architecture, which naturally is
invalid for the arm based architecture. Furthermore, the arm-based
build has non-empty ABIEXTENSION-variable unlike x86/x64 based builds,
which  changes the library name in the PREFERRED_PROVIDER-variable.

To fix these issues, ABIEXTENSION is now added to the library name,
default tune arguments are changed for the arm builds, and the
architecture argument in preferred provider uses 32 bit architecture
name for x86/x64 builds.

Signed-off-by: Erkka Kääriä <erkka.kaaria@intel.com>