### PR TITLE
combo-layer.conf: switch to updating with history by default

### DIFF
--- a/conf/combo-layer.conf
+++ b/conf/combo-layer.conf
@@ -1,5 +1,6 @@
 [DEFAULT]
 signoff = False
+history = True
 
 [bitbake]
 src_uri = git://git.openembedded.org/bitbake


### PR DESCRIPTION
The new "update with history" mode in combo-layer is now in OE-core.
See commit message for the reason why that is useful.