### PR TITLE
combo-layer.conf: allow meta-ostro to have a .gitignore

### DIFF
--- a/conf/combo-layer.conf
+++ b/conf/combo-layer.conf
@@ -27,6 +27,7 @@ last_revision = 9bce6bdccf8ed3d3ae1cc2ae6f1f43c864a4ac34
 [meta-ostro]
 src_uri = git@github.com:ostroproject/meta-ostro.git
 dest_dir = .
+file_exclude = .gitignore
 hook = conf/combo-layerhook-generic.sh
 branch = master
 last_revision = 1d5c23de9f95ce57e52449729b16b955ff4c3cde


### PR DESCRIPTION
Having a .gitignore in meta-ostro is useful, but that only
works if we exclude it when importing, because we already
get an ostro-os/.gitignore from openembedded-core.

This needs to be merged before
https://github.com/ostroproject/meta-ostro/pull/205 can be tested.

I verified manually with combo-layer that updating meta-ostro works
once this PR here is merged.