### PR TITLE
combo-layer.conf: exclude meta-soletta from updates

### DIFF
--- a/conf/combo-layer.conf
+++ b/conf/combo-layer.conf
@@ -122,6 +122,7 @@ dest_dir = meta-soletta
 hook = conf/combo-layerhook-generic.sh
 branch = master
 last_revision = 27ad0bce1117c2079d1333b7ce84f8fcd97ffd7a
+update = no
 
 [meta-swupd]
 src_uri = git://git.yoctoproject.org/meta-swupd


### PR DESCRIPTION
meta-soletta master does not build anymore in Ostro because of the
update to v1beta20
(https://github.com/solettaproject/meta-soletta/issues/97) and
therefore we have to freeze meta-soletta at the current revision.

To achieve that, the entire section has to be taken out of
combo-layer.conf. It could be commented out, but then the next
combo-layer run would just remove it.

The alternative to disabling the updating would be to do manual
updates, but that tends to happen less often and is cumbersome.

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>