### PR TITLE
meta-security-isafw: change layer priority 1 -> 6.

### DIFF
--- a/meta-security-isafw/conf/layer.conf
+++ b/meta-security-isafw/conf/layer.conf
@@ -6,7 +6,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "security-isafw"
 BBFILE_PATTERN_security-isafw = "^${LAYERDIR}/"
-BBFILE_PRIORITY_security-isafw = "1"
+BBFILE_PRIORITY_security-isafw = "6"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers


### PR DESCRIPTION
TEST BUILD, DO NOT MERGE.

Change layer priority to be greater than oe-core priority. Is is so that the patched version of the cve-checker-tool would be used instead of the vanilla version provided by oe-core.
